### PR TITLE
Remove duplicate PlayAgain IDs and harden image selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <div class="shadow rounded p-5" style="background-color: blue;border: 8px solid green;" >
     <img class="only-shake" src="asset/piala2.png" alt="Menang">
     <div class="d-flex justify-content-center">
-      <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: green;" id="PlayAgain" >Mulai Lagi</button>
+      <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: green;">Mulai Lagi</button>
     </div>
   </div>
 </div>
@@ -24,7 +24,7 @@
   <div class="shadow rounded p-5" style="background-color:blue;border: 8px solid red;" >
     <img class="only-shake" src="asset/Kalah.png" alt="Kalah">
     <div class="d-flex justify-content-center">
-      <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: red;" id="PlayAgain" >Coba Lagi</button>
+      <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: red;">Coba Lagi</button>
     </div>
   </div>
 </div>
@@ -33,7 +33,7 @@
   <div class="shadow rounded p-5" style="background-color:blue;border: 8px solid gray;" >
     <img class="only-shake" src="asset/Seimbang.png" alt="Seimbang">
     <div class="d-flex justify-content-center">
-      <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: gray;" id="PlayAgain" >Coba Lagi</button>
+      <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: gray;">Coba Lagi</button>
     </div>
   </div>
 </div>

--- a/script.js
+++ b/script.js
@@ -26,7 +26,7 @@ document.addEventListener("click",(e) => {
     mainWadah.innerHTML = 
     ` 
     <img  data-suit="2" style="opacity: 0;"  src="asset/${imgMusuh}" alt="musuh"><br> 
-    <img class="atas-and-hide" src="asset/${imgPlayer}" alt="palyer" >
+    <img class="atas-and-hide" src="asset/${imgPlayer}" alt="player" >
     `
 
     setTimeout(() => {
@@ -99,21 +99,15 @@ function sistemSuit (player,musuh) {
 }
 
 function imgPilihan (pilihan) {
-  if (pilihan === 0){
-    const img = `Batu.png`
-    return img;
-  }
-
-
-  if (pilihan === 1){
-    const img = `kertas.png`
-    return img;
-  }
-  
-  
-  if(pilihan === 2){
-      const img = `gunting.png`
-      return img;
+  switch (pilihan) {
+    case 0:
+      return `Batu.png`;
+    case 1:
+      return `kertas.png`;
+    case 2:
+      return `gunting.png`;
+    default:
+      throw new Error("Pilihan tidak valid");
   }
 }
 


### PR DESCRIPTION
## Summary
- eliminate duplicate `PlayAgain` IDs from restart buttons for valid HTML
- correct typo in player image alt text and validate selections in `imgPilihan`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960389645883209f3b36aa52644b08