### PR TITLE
Add dark theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,10 @@
 </head>
 <body>
 
+<button id="themeToggle" class="btn btn-secondary position-absolute top-0 end-0 m-3">Dark Mode</button>
+
 <div id="victory" class="justify-content-center align-items-center modal" style="display: none; position: absolute;width: 100%;height: 100%;z-index: 999;" >
-  <div class="shadow rounded p-5" style="background-color: blue;border: 8px solid green;" >
+  <div class="shadow rounded p-5 modal-content-victory" >
     <img class="only-shake" src="asset/piala2.png" alt="Menang">
     <div class="d-flex justify-content-center">
       <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: green;">Mulai Lagi</button>
@@ -21,7 +23,7 @@
 </div>
 
 <div id="lose" class="justify-content-center align-items-center modal" style="display: none; position: absolute;width: 100%;height: 100%;z-index: 999;" >
-  <div class="shadow rounded p-5" style="background-color:blue;border: 8px solid red;" >
+  <div class="shadow rounded p-5 modal-content-lose" >
     <img class="only-shake" src="asset/Kalah.png" alt="Kalah">
     <div class="d-flex justify-content-center">
       <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: red;">Coba Lagi</button>
@@ -30,7 +32,7 @@
 </div>
 
 <div id="seimbang" class="justify-content-center align-items-center modal" style="display: none; position: absolute;width: 100%;height: 100%;z-index: 999;" >
-  <div class="shadow rounded p-5" style="background-color:blue;border: 8px solid gray;" >
+  <div class="shadow rounded p-5 modal-content-seimbang" >
     <img class="only-shake" src="asset/Seimbang.png" alt="Seimbang">
     <div class="d-flex justify-content-center">
       <button class="playAgain mt-2 btn text-light fw-bold" style="background-color: gray;">Coba Lagi</button>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,19 @@ const victory = document.querySelector("#victory");
 const seimbang = document.querySelector("#seimbang");
 const lose = document.querySelector("#lose");
 const score = document.querySelector("#score")
+const themeToggle = document.querySelector("#themeToggle");
+
+if(localStorage.getItem("theme") === "dark"){
+    document.body.classList.add("dark-mode");
+    themeToggle.textContent = "Light Mode";
+}
+
+themeToggle.addEventListener("click", () => {
+    document.body.classList.toggle("dark-mode");
+    const isDark = document.body.classList.contains("dark-mode");
+    themeToggle.textContent = isDark ? "Light Mode" : "Dark Mode";
+    localStorage.setItem("theme", isDark ? "dark" : "light");
+});
 
 if(localStorage.getItem("scoreSuit")){
     score.innerHTML = localStorage.getItem("scoreSuit")

--- a/style.css
+++ b/style.css
@@ -1,5 +1,41 @@
+:root {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+    --modal-bg-victory: blue;
+    --modal-border-victory: green;
+    --modal-bg-lose: blue;
+    --modal-border-lose: red;
+    --modal-bg-seimbang: blue;
+    --modal-border-seimbang: gray;
+}
+
 body {
     overflow: hidden;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+  }
+
+body.dark-mode {
+    --bg-color: #121212;
+    --text-color: #ffffff;
+    --modal-bg-victory: #001d3d;
+    --modal-bg-lose: #001d3d;
+    --modal-bg-seimbang: #001d3d;
+  }
+
+.modal-content-victory {
+    background-color: var(--modal-bg-victory);
+    border: 8px solid var(--modal-border-victory);
+  }
+
+.modal-content-lose {
+    background-color: var(--modal-bg-lose);
+    border: 8px solid var(--modal-border-lose);
+  }
+
+.modal-content-seimbang {
+    background-color: var(--modal-bg-seimbang);
+    border: 8px solid var(--modal-border-seimbang);
   }
 
 .minecraft-item {


### PR DESCRIPTION
## Summary
- add a theme toggle button to switch between light and dark modes
- apply CSS variables and dark-mode styles to update page and modal colors
- persist user theme choice in local storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960904975083209dc57ad3c0f6ac4c