### PR TITLE
feat: improve dark theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@
 </head>
 <body>
 
-<button id="themeToggle" class="btn btn-secondary position-absolute top-0 end-0 m-3">Dark Mode</button>
+<button id="themeToggle" class="theme-toggle position-absolute top-0 end-0 m-3" aria-label="Toggle dark mode">
+  <span class="icon-sun">☀️</span>
+  <span class="icon-moon">🌙</span>
+</button>
 
 <div id="victory" class="justify-content-center align-items-center modal" style="display: none; position: absolute;width: 100%;height: 100%;z-index: 999;" >
   <div class="shadow rounded p-5 modal-content-victory" >

--- a/script.js
+++ b/script.js
@@ -8,13 +8,15 @@ const themeToggle = document.querySelector("#themeToggle");
 
 if(localStorage.getItem("theme") === "dark"){
     document.body.classList.add("dark-mode");
-    themeToggle.textContent = "Light Mode";
+    themeToggle.setAttribute("aria-label", "Switch to light mode");
+}else{
+    themeToggle.setAttribute("aria-label", "Switch to dark mode");
 }
 
 themeToggle.addEventListener("click", () => {
     document.body.classList.toggle("dark-mode");
     const isDark = document.body.classList.contains("dark-mode");
-    themeToggle.textContent = isDark ? "Light Mode" : "Dark Mode";
+    themeToggle.setAttribute("aria-label", isDark ? "Switch to light mode" : "Switch to dark mode");
     localStorage.setItem("theme", isDark ? "dark" : "light");
 });
 

--- a/style.css
+++ b/style.css
@@ -15,6 +15,41 @@ body {
     color: var(--text-color);
   }
 
+  .theme-toggle {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    border: 2px solid var(--text-color);
+    background-color: var(--bg-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: transform 0.3s, background-color 0.3s, border-color 0.3s;
+  }
+
+  .theme-toggle:hover {
+    transform: scale(1.1);
+  }
+
+  .theme-toggle .icon-sun,
+  .theme-toggle .icon-moon {
+    font-size: 24px;
+    transition: opacity 0.3s;
+  }
+
+  .theme-toggle .icon-moon {
+    opacity: 0;
+  }
+
+  body.dark-mode .theme-toggle .icon-sun {
+    opacity: 0;
+  }
+
+  body.dark-mode .theme-toggle .icon-moon {
+    opacity: 1;
+  }
+
 body.dark-mode {
     --bg-color: #121212;
     --text-color: #ffffff;


### PR DESCRIPTION
## Summary
- revamp dark mode toggle with sun and moon icons
- style toggle as animated circular button
- adjust script to handle icon-based toggle and aria labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896113488288320af3e70a47c085788